### PR TITLE
Update npc_buffer.cpp - change uint to unit32

### DIFF
--- a/src/npc_buffer.cpp
+++ b/src/npc_buffer.cpp
@@ -137,7 +137,7 @@ public:
     /** Get the most level-appropriate spell from the chain, 
      * based on character level compared to max level (MaxLevel)
      *  */
-    static uint GetSpellForLevel(uint32 spell_id, Player *player)
+    static uint32 GetSpellForLevel(uint32 spell_id, Player *player)
     {
         uint32 level = player->GetLevel();
 


### PR DESCRIPTION


## Changes Proposed:
Update npc_buffer.cpp, 
static uint GetSpellForLevel(uint32 spell_id, Player *player)
Change to uint32

## Issues Addressed:
Fix Windows compilation errors. 
Closes #40


## SOURCE:


## Tests Performed:
Core now compiles with npc_buffer without errors on Windows 11 as of 1/4/2025